### PR TITLE
feat: make water heater entity unavailable on connection lost

### DIFF
--- a/custom_components/rinnai/__init__.py
+++ b/custom_components/rinnai/__init__.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import aiohttp
+import time
 
 from datetime import timedelta
 
@@ -98,6 +99,9 @@ class RinnaiHeater:
 
         self.data = {}
 
+        self._last_success = time.time()
+        self._timeout = 0
+
     @callback
     async def async_add_rinnai_heater_sensor(self, update_callback):
         # This is the first sensor, set up interval.
@@ -105,6 +109,7 @@ class RinnaiHeater:
             scan_interval_bus = self._entry.data.get(CONF_SCAN_INTERVAL_BUS, DEFAULT_SCAN_INTERVAL_BUS)
             scan_interval_tela = self._entry.data.get(CONF_SCAN_INTERVAL_TELA, DEFAULT_SCAN_INTERVAL_TELA)
             scan_interval_consumo = self._entry.data.get(CONF_SCAN_INTERVAL_CONSUMO, DEFAULT_SCAN_INTERVAL_CONSUMO)
+            self._timeout = max(scan_interval_bus, scan_interval_tela) * 4
 
             a = (
                 async_track_time_interval(self._hass, self.bus, timedelta(seconds=scan_interval_bus))
@@ -149,15 +154,23 @@ class RinnaiHeater:
             try:
                 res = await self._client.get(f"http://{self._host}/{endpoint}")
                 read = await res.text()
+                self._last_success = time.time()
                 return read.split(",")
             except aiohttp.client_exceptions.ServerDisconnectedError:
                 return True  # not even an empty response, the priority endpoint simply closes the TCP connection
+            except aiohttp.client_exceptions.ClientConnectorError:
+                return False
+            except aiohttp.client_exceptions.ServerTimeoutError:
+                return False
             except Exception:
                 _LOGGER.exception(f"Error fetching /{endpoint} data", exc_info=True)
                 return False
             finally:
                 self._reading = False
 
+    def is_connected(self):
+        return time.time() - self._last_success < self._timeout
+    
     async def inc(self):
         return self.update_data(await self.request("inc"), SENSORS_TELA_ARRAY)
 
@@ -181,7 +194,9 @@ class RinnaiHeater:
         return await self.request(f"ip:{priority}:pri")
 
     def update_data(self, response: list[str], sensors: dict[int, str], update_entities=True):
-        no_response = response is None or response is False
+        if response is None or response is False:
+            return False
+    
         response = response or {}
 
         for name, address in sensors.items():
@@ -191,7 +206,7 @@ class RinnaiHeater:
             for update_callback in self._sensors:
                 update_callback()
 
-        return not no_response
+        return True
 
     def _device_info(self):
         return {

--- a/custom_components/rinnai/__init__.py
+++ b/custom_components/rinnai/__init__.py
@@ -194,9 +194,7 @@ class RinnaiHeater:
         return await self.request(f"ip:{priority}:pri")
 
     def update_data(self, response: list[str], sensors: dict[int, str], update_entities=True):
-        if response is None or response is False:
-            return False
-    
+        no_response = response is None or response is False
         response = response or {}
 
         for name, address in sensors.items():
@@ -206,7 +204,7 @@ class RinnaiHeater:
             for update_callback in self._sensors:
                 update_callback()
 
-        return True
+        return not no_response
 
     def _device_info(self):
         return {

--- a/custom_components/rinnai/water_heater.py
+++ b/custom_components/rinnai/water_heater.py
@@ -118,8 +118,8 @@ class RinnaiHeaterWaterHeater(WaterHeaterEntity):
 
     @property
     def available(self) -> dict[str, Any] | None:
-        return True
-
+        return self._heater.is_connected()
+    
     @property
     def capability_attributes(self) -> dict[str, Any]:
         # https://github.com/home-assistant/core/pull/130722/files


### PR DESCRIPTION
Relativo a issue #29 (Gerenciamento de desconexão), se por 4 updates falha a conexão com o aquecedor ele seta o available do heater para false, assim que consegue conexão novamente volta para true.

Na automação por exemplo, dá pra checar `is_state('water_heater.rinnai_aquecedor', 'unavailable')`

Além disso filtra melhor os erros para não ficar spam de mensagem no log do HA.

Acho isso importante porque o wifi do módulo é bem sensivel, menor que -65dBM ja costuma cair a conexão.